### PR TITLE
Remove magic numbers and unmarshal stream.

### DIFF
--- a/recast/conversation.go
+++ b/recast/conversation.go
@@ -2,9 +2,9 @@ package recast
 
 import (
 	"fmt"
-	"time"
-
 	"github.com/parnurzeal/gorequest"
+	"net/http"
+	"time"
 )
 
 type Action struct {
@@ -60,7 +60,7 @@ func (conv *Conversation) SetMemory(memory map[string]map[string]interface{}) er
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("Request failed(%s): %s", resp.Status, response.Message)
 	}
 
@@ -91,7 +91,7 @@ func (conv *Conversation) ResetMemory() error {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("Request failed(%s): %s", resp.Status, response.Message)
 	}
 
@@ -114,7 +114,7 @@ func (conv *Conversation) Reset() error {
 		return requestErr[0]
 	}
 
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("Request failed(%s): %s", resp.Status, response.Message)
 	}
 

--- a/recast/request.go
+++ b/recast/request.go
@@ -3,10 +3,10 @@ package recast
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
-	"path/filepath"
-
 	"github.com/parnurzeal/gorequest"
+	"io/ioutil"
+	"net/http"
+	"path/filepath"
 )
 
 var (
@@ -83,7 +83,7 @@ func (c *RequestClient) AnalyzeText(text string, opts *ReqOpts) (Response, error
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		return Response{}, fmt.Errorf("Request failed (%s): %s", resp.Status, response.Message)
 	}
 	response.Results.CustomEntities = getCustomEntities(body)
@@ -151,7 +151,7 @@ func (c *RequestClient) AnalyzeFile(filename string, opts *ReqOpts) (Response, e
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		return Response{}, fmt.Errorf("Request failed (%s): %s", resp.Status, response.Message)
 	}
 	response.Results.CustomEntities = getCustomEntities(body)
@@ -235,7 +235,7 @@ func (c *RequestClient) ConverseText(text string, opts *ConverseOpts) (Conversat
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		return Conversation{}, fmt.Errorf("Request failed (%s): %s", resp.Status, response.Message)
 	}
 


### PR DESCRIPTION
Replace every 200/201 statements with the corresponding constant within
the `net/http` package.

As `Request.Body` implements `io.Reader`, using `Decoder` seems to be
more appropriate.

See: http://stackoverflow.com/questions/21197239/decoding-json-in-golang-using-json-unmarshal-vs-json-newdecoder-decode