### PR TITLE
[WIP] fix gometalinter warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+# Created by .ignore support plugin (hsz.mobi)

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,23 @@
+# Created by https://www.gitignore.io/api/go
+
+### Go ###
+# Binaries for programs and plugins
+*.exe
+*.dll
+*.so
+*.dylib
+
+# Test binary, build with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
+.glide/
+
 # Created by .ignore support plugin (hsz.mobi)
+.idea/
+
+
+# End of https://www.gitignore.io/api/go

--- a/.gometalinter.json
+++ b/.gometalinter.json
@@ -1,0 +1,7 @@
+{
+  "Linters": {
+    "gocyclo": {"Command": "gocyclo -over 15"}
+  },
+  "EnableAll": true,
+  "EnableGC": true
+}

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/recast/components.go
+++ b/recast/components.go
@@ -6,11 +6,13 @@ type Component interface {
 	IsComponent() bool
 }
 
+//Carousel complex type see https://recast.ai/docs/structured-messages for details
 type Carousel struct {
 	Type    string          `json:"type"`
 	Content []*CarouselCard `json:"content"`
 }
 
+//NewCarousel create new Carousel see https://recast.ai/docs/structured-messages for details
 func NewCarousel() *Carousel {
 	return &Carousel{
 		Type:    "carousel",
@@ -18,36 +20,42 @@ func NewCarousel() *Carousel {
 	}
 }
 
+//AddCard append card component into Carousel
 func (c *Carousel) AddCard(card *CarouselCard) *Carousel {
 	c.Content = append(c.Content, card)
 	return c
 }
 
+//IsComponent CarouselCard is Component
 func (c *Carousel) IsComponent() bool {
 	return true
 }
 
+//CarouselCard item of Carousel see https://recast.ai/docs/structured-messages for details
 type CarouselCard struct {
 	Title    string       `json:"title"`
 	Subtitle string       `json:"subtitle"`
-	ImageUrl string       `json:"imageUrl"`
+	ImageURL string       `json:"imageUrl"`
 	Buttons  []CardButton `json:"buttons"`
 }
 
+//NewCarouselCard create of CarouselCard see https://recast.ai/docs/structured-messages for details
 func NewCarouselCard(title, subtitle string) *CarouselCard {
 	return &CarouselCard{
 		Title:    title,
 		Subtitle: subtitle,
-		ImageUrl: "",
+		ImageURL: "",
 		Buttons:  []CardButton{},
 	}
 }
 
+//AddImage add image_url
 func (c *CarouselCard) AddImage(image string) *CarouselCard {
-	c.ImageUrl = image
+	c.ImageURL = image
 	return c
 }
 
+//AddButton add button to CarouselCard.Buttons
 func (c *CarouselCard) AddButton(title, typ, value string) *CarouselCard {
 	c.Buttons = append(c.Buttons, CardButton{title, typ, value})
 	return c
@@ -59,7 +67,7 @@ type ListButton CardButton
 // ListElement holds data for one list item
 type ListElement struct {
 	Title    string       `json:"title"`
-	ImageUrl string       `json:"imageUrl"`
+	ImageURL string       `json:"imageUrl"`
 	Subtitle string       `json:"subtitle"`
 	Buttons  []ListButton `json:"buttons"`
 }
@@ -69,14 +77,14 @@ func NewListElement(title, subtitle string) *ListElement {
 	return &ListElement{
 		Title:    title,
 		Subtitle: subtitle,
-		ImageUrl: "",
+		ImageURL: "",
 		Buttons:  []ListButton{},
 	}
 }
 
 // AddImage adds an image to a list element
 func (e *ListElement) AddImage(image string) *ListElement {
-	e.ImageUrl = image
+	e.ImageURL = image
 	return e
 }
 
@@ -147,7 +155,7 @@ type CardButton struct {
 type CardContent struct {
 	Title    string       `json:"title"`
 	Subtitle string       `json:"subtitle"`
-	ImageUrl string       `json:"imageUrl"`
+	ImageURL string       `json:"imageUrl"`
 	Buttons  []CardButton `json:"buttons"`
 }
 
@@ -180,8 +188,8 @@ func (c *Card) IsComponent() bool {
 }
 
 // AddImage sets the image that will be displayed in the message
-func (c *Card) AddImage(imageUrl string) *Card {
-	c.Content.ImageUrl = imageUrl
+func (c *Card) AddImage(imageURL string) *Card {
+	c.Content.ImageURL = imageURL
 	return c
 }
 

--- a/recast/components_test.go
+++ b/recast/components_test.go
@@ -1,6 +1,8 @@
 package recast
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestComponentsInterface(t *testing.T) {
 	// Attachment, Cards and QuickReplies should implement IsComponent
@@ -19,14 +21,52 @@ func TestComponentsInterface(t *testing.T) {
 	}
 
 	if !card.IsComponent() {
-		t.Fatalf("Card should implement IsComponent")
+		t.Fatalf("card should implement IsComponent")
 	}
 
 	if !attachment.IsComponent() {
-		t.Fatalf("Card should implement IsComponent")
+		t.Fatalf("attachment should implement IsComponent")
 	}
 
 	if !quickReplies.IsComponent() {
-		t.Fatalf("Card should implement IsComponent")
+		t.Fatalf("quickReplies should implement IsComponent")
+	}
+
+	//All other components
+	carousel := NewCarousel()
+	if !carousel.IsComponent() {
+		t.Fatalf("carousel should implement IsComponent")
+	}
+
+	listElement := NewListElement("title", "subtitle")
+	list := NewList()
+	list.AddButton("Button", "postback", "Button Content")
+	list.AddElement(listElement)
+	if !list.IsComponent() {
+		t.Fatalf("list should implement IsComponent")
+	}
+	if len(list.Content.Elements) != 1 {
+		t.Fatalf("list should contains one Element")
+
+	}
+	if len(list.Content.Buttons) != 1 {
+		t.Fatalf("list should contains one Button")
+	}
+	for _, b := range list.Content.Buttons {
+		if b.Title != "Button" {
+			t.Fatalf("button should have right Title")
+		}
+	}
+
+	carouselCard := NewCarouselCard("carousel card title", "subtitle").
+		AddImage("image_url").
+		AddButton("Button", "postback", "Button content")
+
+	if carouselCard.ImageURL != "image_url" {
+		t.Fatalf("carouselCard should have right ImageURL")
+	}
+
+	if len(carouselCard.Buttons) != 1 {
+		t.Fatalf("carouselCard should contains one Button")
 	}
 }

--- a/recast/connect.go
+++ b/recast/connect.go
@@ -7,31 +7,36 @@ import (
 	"net/http"
 
 	"github.com/parnurzeal/gorequest"
+	"strconv"
 )
 
 const (
-	conversationsEndpoint string = "https://api.recast.ai/connect/v1/conversations/"
-	messagesEndpoint      string = "https://api.recast.ai/connect/v1/messages/"
+	conversationsEndpoint = "https://api.recast.ai/connect/v1/conversations/"
+	messagesEndpoint      = "https://api.recast.ai/connect/v1/messages/"
 )
 
 var (
+	//ErrNoMessageToSend return when you try send empty Component list
 	ErrNoMessageToSend = errors.New("No message to send")
-	ErrNoRequestBody   = errors.New("The request's body is empty")
+	//ErrNoRequestBody return when you try parse empty request body
+	ErrNoRequestBody = errors.New("The request's body is empty")
+	//ErrNoRequestConversationID return when you try send empty conversationID
+	ErrNoRequestConversationID = errors.New("The request's conversationID is empty")
 )
 
 // Message contains data sent by Recast.AI connector.
 type Message struct {
-	ConversationId string     `json:"conversation"`
+	ConversationID string     `json:"conversation"`
 	Attachment     Attachment `json:"attachment"`
-	SenderId       string
-	ChatId         string
+	SenderID       uint64
+	ChatID         uint64
 }
 
 // MessageData contains the Message and messaging informations about the message
 type MessageData struct {
 	Message  Message `json:"message"`
-	SenderId string  `json:"senderId"`
-	ChatId   string  `json:"chatId"`
+	SenderID uint64  `json:"senderId"`
+	ChatID   uint64  `json:"chatId"`
 }
 
 // ParseConnectorMessage handles a request coming from BotConnector API.
@@ -46,8 +51,8 @@ func ParseConnectorMessage(r *http.Request) (Message, error) {
 	if err := json.NewDecoder(r.Body).Decode(&msg); err != nil {
 		return Message{}, err
 	}
-	msg.Message.SenderId = msg.SenderId
-	msg.Message.ChatId = msg.ChatId
+	msg.Message.SenderID = msg.SenderID
+	msg.Message.ChatID = msg.ChatID
 
 	return msg.Message, nil
 }
@@ -62,7 +67,7 @@ type MessageHandler interface {
 type MessageHandlerFunc func(w MessageWriter, m Message)
 
 func defaultMessageHandler(w MessageWriter, m Message) {
-	fmt.Printf("Message received: %v \n", m)
+	fmt.Printf("Message received: %v you can try write him over %v\n", m, w)
 }
 
 // ServeMessage implements the MessageHandler interface.
@@ -104,12 +109,15 @@ func NewConnectClient(token string) *ConnectClient {
 //		AddButton("Say hello", "postback", "Hello").
 //		AddButton("Say goodbyes", "postback", "Goodbye")
 //	err := client.SendMessage("CONVERSATION_ID", card)
-func (client *ConnectClient) SendMessage(conversationId string, messages ...Component) error {
+func (client *ConnectClient) SendMessage(conversationID string, messages ...Component) error {
 	if len(messages) == 0 {
 		return ErrNoMessageToSend
 	}
+	if conversationID == "" {
+		return ErrNoRequestConversationID
+	}
 	httpClient := gorequest.New()
-	endpoint := conversationsEndpoint + conversationId + "/messages"
+	endpoint := conversationsEndpoint + conversationID + "/messages"
 
 	send := struct {
 		Messages []Component `json:"messages"`
@@ -119,13 +127,18 @@ func (client *ConnectClient) SendMessage(conversationId string, messages ...Comp
 		Message string `json:"message"`
 	}
 
-	resp, _, requestErr := httpClient.
+	resp, respBytes, requestErr := httpClient.
 		Post(endpoint).
 		Send(send).
 		Set("Authorization", fmt.Sprintf("Token %s", client.Token)).
 		EndStruct(&response)
 
 	if requestErr != nil {
+		fmt.Println(resp)
+		fmt.Println(respBytes)
+		for _, err := range requestErr {
+			fmt.Println(err)
+		}
 		return requestErr[0]
 	}
 
@@ -188,7 +201,7 @@ type messageWriter struct {
 }
 
 func (m *messageWriter) Reply(messages ...Component) error {
-	return m.client.SendMessage(m.Context.ConversationId, messages...)
+	return m.client.SendMessage(m.Context.ConversationID, messages...)
 }
 
 func (m *messageWriter) Broadcast(messages ...Component) error {
@@ -204,7 +217,7 @@ func (client *ConnectClient) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if client.handler != nil {
 		writer := &messageWriter{
 			client:  client,
-			Context: &Context{ConversationId: message.ConversationId, SenderId: message.SenderId},
+			Context: &Context{ConversationID: message.ConversationID, SenderID: strconv.FormatUint(message.SenderID, 10)},
 		}
 		go client.handler.ServeMessage(writer, message)
 	}

--- a/recast/connect_test.go
+++ b/recast/connect_test.go
@@ -24,31 +24,31 @@ func TestSendMessageParameters(t *testing.T) {
 		Type:    "text",
 	}
 	client := NewConnectClient("recast_token")
-	conversationId := "conversation_id"
+	conversationID := "conversation_id"
 
 	gorequest.DisableTransportSwap = true
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 
 	res := httpmock.NewStringResponder(http.StatusCreated, getSuccessfulPostMessageResponse())
-	httpmock.RegisterResponder("POST", conversationsEndpoint+conversationId+"/messages", res)
+	httpmock.RegisterResponder("POST", conversationsEndpoint+conversationID+"/messages", res)
 
-	err := client.SendMessage(conversationId, attachment, card, quickReplies)
+	err := client.SendMessage(conversationID, attachment, card, quickReplies)
 	if err != nil {
 		t.Fatalf("Expected err to be nil, but instead got %+v", err)
 	}
 
-	err = client.SendMessage(conversationId, card, quickReplies)
+	err = client.SendMessage(conversationID, card, quickReplies)
 	if err != nil {
 		t.Fatalf("Expected err to be nil, but instead got %+v", err)
 	}
 
-	err = client.SendMessage(conversationId, attachment, quickReplies, card)
+	err = client.SendMessage(conversationID, attachment, quickReplies, card)
 	if err != nil {
 		t.Fatalf("Expected err to be nil, but instead got %+v", err)
 	}
 
-	err = client.SendMessage(conversationId)
+	err = client.SendMessage(conversationID)
 	if err == nil {
 		t.Fatalf("Expected err not to be nil, but instead got nil")
 	}
@@ -56,28 +56,34 @@ func TestSendMessageParameters(t *testing.T) {
 }
 
 func TestSendMessageErrors(t *testing.T) {
+	var err error
 	attachment := Attachment{
 		Content: "Hello",
 		Type:    "bad_type",
 	}
 	client := NewConnectClient("recast_token")
-	conversationId := "conversation_id"
+	conversationID := "conversation_id"
 
 	gorequest.DisableTransportSwap = true
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 
 	res := httpmock.NewStringResponder(http.StatusBadRequest, getBadRequestJSONResponse())
-	httpmock.RegisterResponder("POST", conversationsEndpoint+conversationId+"/messages", res)
+	httpmock.RegisterResponder("POST", conversationsEndpoint+conversationID+"/messages", res)
 
-	err := client.SendMessage(conversationId, attachment)
+	err = client.SendMessage("", attachment)
+	if err == nil {
+		t.Fatalf("Expected err not to be nil, but instead got nil")
+	}
+
+	err = client.SendMessage(conversationID, attachment)
 	if err == nil {
 		t.Fatalf("Expected err not to be nil, but instead got nil")
 	}
 
 	res = httpmock.NewStringResponder(http.StatusInternalServerError, getServerErrorJSONResponse())
-	httpmock.RegisterResponder("POST", conversationsEndpoint+conversationId+"/messages", res)
-	err = client.SendMessage(conversationId, attachment)
+	httpmock.RegisterResponder("POST", conversationsEndpoint+conversationID+"/messages", res)
+	err = client.SendMessage(conversationID, attachment)
 	if err == nil {
 		t.Fatalf("Expected err not to be nil, but instead got nil")
 	}
@@ -174,7 +180,7 @@ func TestParseMessage(t *testing.T) {
 		t.Error("Payload should be considered as valid")
 	}
 
-	if msg.ConversationId != "f206b482-cb0c-435b-91bc-4628c8829d83" {
+	if msg.ConversationID != "f206b482-cb0c-435b-91bc-4628c8829d83" {
 		t.Error("Invalid conversation id")
 	}
 }

--- a/recast/constants.go
+++ b/recast/constants.go
@@ -1,29 +1,42 @@
 package recast
 
 const (
-	trainEndpoint    string = "https://api.recast.ai/v2/"
-	connectEndpoint  string = "https://api.recast.ai/connect/v1/"
-	hostEndpoint     string = "https://api.recast.ai/host/v1/"
-	requestEndpoint  string = "https://api.recast.ai/v2/request/"
-	converseEndpoint string = "https://api.recast.ai/v2/converse/"
-	monitorEndpoint  string = "https://api.recast.ai/monitor/v1/"
-	dialogEndpoint   string = "https://api.recast.ai/build/v1/dialog"
-
-	ActAssert  = "assert"
+	//@TODO uncomment this const when this API will be implements
+	//trainEndpoint    = "https://api.recast.ai/v2/"
+	//connectEndpoint  = "https://api.recast.ai/connect/v1/"
+	//hostEndpoint     = "https://api.recast.ai/host/v1/"
+	//monitorEndpoint  = "https://api.recast.ai/monitor/v1/"
+	requestEndpoint  = "https://api.recast.ai/v2/request/"
+	converseEndpoint = "https://api.recast.ai/v2/converse/"
+	dialogEndpoint   = "https://api.recast.ai/build/v1/dialog"
+	//ActAssert used in Response.IsAssert()
+	ActAssert = "assert"
+	//ActCommand used in Response.IsCommand()
 	ActCommand = "command"
+	//ActWhQuery used in Response.IsWhQuery()
 	ActWhQuery = "wh-query"
+	//ActYnQuery used in Response.IsYhQuery()
 	ActYnQuery = "yn-query"
-
+	//TypeAbbreviation used in Response.IsAbbreviation()
 	TypeAbbreviation = "abbr:"
-	TypeEntity       = "enty:"
-	TypeDescription  = "desc:"
-	TypeHuman        = "hum:"
-	TypeLocation     = "loc:"
-	TypeNumber       = "num:"
-
-	SentimentPositive     = "positive"
+	//TypeEntity used in Response.IsEntity()
+	TypeEntity = "enty:"
+	//TypeDescription used in Response.IsDescription()
+	TypeDescription = "desc:"
+	//TypeHuman used in Response.IsHuman()
+	TypeHuman = "hum:"
+	//TypeLocation used in Response.IsLocation()
+	TypeLocation = "loc:"
+	//TypeNumber used in Response.IsNumber()
+	TypeNumber = "num:"
+	//SentimentPositive used in Response.IsPositive() and Conversation.IsPositive()
+	SentimentPositive = "positive"
+	//SentimentVeryPositive used in Response.IsVeryPositive() and Conversation.IsVeryPositive()
 	SentimentVeryPositive = "vpositive"
-	SentimentNegative     = "negative"
+	//SentimentNegative used in Response.IsNegative() and Conversation.IsNegative()
+	SentimentNegative = "negative"
+	//SentimentVeryNegative used in Response.IsVeryNegative() and Conversation.IsVeryNegative()
 	SentimentVeryNegative = "vnegative"
-	SentimentNeutral      = "neutral"
+	//SentimentNeutral used in Response.IsNeutral() and Conversation.IsNeutral()
+	SentimentNeutral = "neutral"
 )

--- a/recast/context.go
+++ b/recast/context.go
@@ -3,6 +3,6 @@ package recast
 // Context holds the information
 // about a conversation context
 type Context struct {
-	ConversationId string
-	SenderId       string
+	ConversationID string
+	SenderID       string
 }

--- a/recast/dialog.go
+++ b/recast/dialog.go
@@ -5,8 +5,9 @@ import (
 	"fmt"
 )
 
+//DialogConversation see https://recast.ai/docs/api-reference/#dialog-text
 type DialogConversation struct {
-	Id              string                 `json:"id"`
+	ID              string                 `json:"id"`
 	Language        string                 `json:"language"`
 	Skill           string                 `json:"skill"`
 	SkillOccurences int                    `json:"skill_occurences"`

--- a/recast/entity.go
+++ b/recast/entity.go
@@ -1,7 +1,7 @@
 package recast
 
 var (
-	goldEntities []string = []string{
+	goldEntities = []string{
 		"cardinal",
 		"color",
 		"datetime",
@@ -145,8 +145,8 @@ type Emoji struct {
 	Confidence  float64  `json:"confidence"`
 }
 
-// Ip Recast.AI entity
-type Ip struct {
+// IP Recast.AI entity
+type IP struct {
 	Formatted  string  `json:"formatted"`
 	Lat        float64 `json:"lat"`
 	Lng        float64 `json:"lng"`
@@ -306,8 +306,8 @@ type Temperature struct {
 	Confidence float64 `json:"confidence"`
 }
 
-// Url Recast.AI entity
-type Url struct {
+// URL Recast.AI entity
+type URL struct {
 	Scheme     string  `json:"scheme"`
 	Host       string  `json:"host"`
 	Path       string  `json:"path"`

--- a/recast/entity_test.go
+++ b/recast/entity_test.go
@@ -58,13 +58,13 @@ const (
 )
 
 func TestCustomEntityParsing(t *testing.T) {
-	var rawEntities rawEntities
-	err := json.Unmarshal([]byte(jsonWithCustoms), &rawEntities)
+	var entities rawEntities
+	err := json.Unmarshal([]byte(jsonWithCustoms), &entities)
 	if err != nil {
 		t.Fatal("Could not unmarshal json test")
 	}
 
-	customs := getCustomEntities(rawEntities.Results.Entities)
+	customs := getCustomEntities(entities.Results.Entities)
 	if len(customs) != 3 {
 		t.Fatal("Wrong number of custom entities parsed")
 	}

--- a/recast/json_test.go
+++ b/recast/json_test.go
@@ -157,8 +157,8 @@ func getValidConversationMessage() string {
 		"isActive": true,
 		"_id": "61a7921b-f771-4211-82ca-05885160fd6d"
 	},
-	"chatId": "chatId",
-	"senderId": "senderId"
+	"chatId": 123456,
+	"senderId": 123467
 }`
 }
 

--- a/recast/request.go
+++ b/recast/request.go
@@ -95,12 +95,12 @@ func (c *RequestClient) AnalyzeText(text string, opts *ReqOpts) (Response, error
 		return Response{}, fmt.Errorf("Request failed (%s): %s", resp.Status, response.Message)
 	}
 
-	var rawEntities rawEntities
-	err := json.Unmarshal(body, &rawEntities)
+	var entities rawEntities
+	err := json.Unmarshal(body, &entities)
 	if err != nil {
 		return Response{}, err
 	}
-	response.Results.CustomEntities = getCustomEntities(rawEntities.Results.Entities)
+	response.Results.CustomEntities = getCustomEntities(entities.Results.Entities)
 
 	return response.Results, nil
 }
@@ -169,13 +169,13 @@ func (c *RequestClient) AnalyzeFile(filename string, opts *ReqOpts) (Response, e
 		return Response{}, fmt.Errorf("Request failed (%s): %s", resp.Status, response.Message)
 	}
 
-	var rawEntities rawEntities
-	err = json.Unmarshal(body, &rawEntities)
+	var entities rawEntities
+	err = json.Unmarshal(body, &entities)
 	if err != nil {
 		return Response{}, err
 	}
 
-	response.Results.CustomEntities = getCustomEntities(rawEntities.Results.Entities)
+	response.Results.CustomEntities = getCustomEntities(entities.Results.Entities)
 
 	return response.Results, nil
 }
@@ -262,12 +262,12 @@ func (c *RequestClient) ConverseText(text string, opts *ConverseOpts) (Conversat
 
 	conversation := response.Results
 
-	var rawEntities rawEntities
-	err := json.Unmarshal(body, &rawEntities)
+	var entities rawEntities
+	err := json.Unmarshal(body, &entities)
 	if err != nil {
 		return Conversation{}, err
 	}
-	conversation.CustomEntities = getCustomEntities(rawEntities.Results.Entities)
+	conversation.CustomEntities = getCustomEntities(entities.Results.Entities)
 	conversation.AuthorizationToken = token
 
 	return conversation, nil
@@ -276,13 +276,13 @@ func (c *RequestClient) ConverseText(text string, opts *ConverseOpts) (Conversat
 // DialogOpts contains options for DialogText method
 type DialogOpts struct {
 	Language       string
-	ConversationId string
+	ConversationID string
 	Token          string
 }
 
 type dialogForm struct {
 	Language       string            `json:"language"`
-	ConversationId string            `json:"conversation_id"`
+	ConversationID string            `json:"conversation_id"`
 	Message        dialogFormMessage `json:"message"`
 }
 
@@ -291,8 +291,9 @@ type dialogFormMessage struct {
 	Content string `json:"content"`
 }
 
+//DialogText retrieve all metadata, intents and replies from a sentence
 func (c *RequestClient) DialogText(text string, opts *DialogOpts) (Dialog, error) {
-	var conversationId string
+	var conversationID string
 	lang := c.Language
 	token := c.Token
 
@@ -304,8 +305,8 @@ func (c *RequestClient) DialogText(text string, opts *DialogOpts) (Dialog, error
 		if opts.Token != "" {
 			token = opts.Token
 		}
-		if opts.ConversationId != "" {
-			conversationId = opts.ConversationId
+		if opts.ConversationID != "" {
+			conversationID = opts.ConversationID
 		}
 	}
 
@@ -315,7 +316,7 @@ func (c *RequestClient) DialogText(text string, opts *DialogOpts) (Dialog, error
 
 	send := dialogForm{
 		Message:        dialogFormMessage{Type: "text", Content: text},
-		ConversationId: conversationId,
+		ConversationID: conversationID,
 		Language:       lang,
 	}
 

--- a/recast/response.go
+++ b/recast/response.go
@@ -16,7 +16,7 @@ type Entities struct {
 	Duration     []Duration     `json:"duration"`
 	Email        []Email        `json:"email"`
 	Emoji        []Emoji        `json:"emoji"`
-	Ip           []Ip           `json:"ip"`
+	IP           []IP           `json:"ip"`
 	Interval     []Interval     `json:"interval"`
 	Job          []Job          `json:"job"`
 	Language     []Language     `json:"language"`


### PR DESCRIPTION
This pull request fix gometalinter warnings
```
recast\components.go:15:1:warning: comment on exported function NewCarousel should be of the form "NewCarousel ..." (golint)
recast\components.go:23:1:warning: exported method Carousel.AddCard should have comment or be unexported (golint)
recast\components.go:28:1:warning: exported method Carousel.IsComponent should have comment or be unexported (golint)
recast\components.go:32:6:warning: exported type CarouselCard should have comment or be unexported (golint)
recast\components.go:35:2:warning: struct field ImageUrl should be ImageURL (golint)
recast\components.go:39:1:warning: exported function NewCarouselCard should have comment or be unexported (golint)
recast\components.go:48:1:warning: exported method CarouselCard.AddImage should have comment or be unexported (golint)
recast\components.go:53:1:warning: exported method CarouselCard.AddButton should have comment or be unexported (golint)
recast\components.go:64:2:warning: struct field ImageUrl should be ImageURL (golint)
recast\components.go:152:2:warning: struct field ImageUrl should be ImageURL (golint)
recast\components.go:185:25:warning: method parameter imageUrl should be imageURL (golint)
recast\connect.go:19:2:warning: exported var ErrNoMessageToSend should have comment or be unexported (golint)
recast\connect.go:25:2:warning: struct field ConversationId should be ConversationID (golint)
recast\connect.go:27:2:warning: struct field SenderId should be SenderID (golint)
recast\connect.go:28:2:warning: struct field ChatId should be ChatID (golint)
recast\connect.go:34:2:warning: struct field SenderId should be SenderID (golint)
recast\connect.go:35:2:warning: struct field ChatId should be ChatID (golint)
recast\connect.go:108:42:warning: method parameter conversationId should be conversationID (golint)
recast\connect_test.go:27:2:warning: var conversationId should be conversationID (golint)
recast\connect_test.go:64:2:warning: var conversationId should be conversationID (golint)
recast\constants.go:12:2:warning: exported const ActAssert should have comment (or a comment on this block) or be unexported (golint)
recast\context.go:6:2:warning: struct field ConversationId should be ConversationID (golint)
recast\context.go:7:2:warning: struct field SenderId should be SenderID (golint)
recast\dialog.go:8:6:warning: exported type DialogConversation should have comment or be unexported (golint)
recast\dialog.go:9:2:warning: struct field Id should be ID (golint)
recast\entity.go:4:15:warning: should omit type []string from declaration of var goldEntities; it will be inferred from the right-hand side (golint)
recast\entity.go:149:6:warning: type Ip should be IP (golint)
recast\entity.go:310:6:warning: type Url should be URL (golint)
recast\request.go:279:2:warning: struct field ConversationId should be ConversationID (golint)
recast\request.go:285:2:warning: struct field ConversationId should be ConversationID (golint)
recast\request.go:294:1:warning: exported method RequestClient.DialogText should have comment or be unexported (golint)
recast\request.go:295:6:warning: var conversationId should be conversationID (golint)
recast\response.go:19:2:warning: struct field Ip should be IP (golint)
recast\request.go:98::warning: declaration of "rawEntities" shadows declaration at github.com/Slach/Recast-Golang-SDK/recast/request.go:36 (vetshadow)
recast/request.go:172::warning: declaration of "rawEntities" shadows declaration at github.com/Slach/Recast-Golang-SDK/recast/request.go:36 (vetshadow)
recast/request.go:265::warning: declaration of "rawEntities" shadows declaration at github.com/Slach/Recast-Golang-SDK/recast/request.go:36 (vetshadow)
recast/entity_test.go:61::warning: declaration of "rawEntities" shadows declaration at github.com/Slach/Recast-Golang-SDK/recast/request.go:36 (vetshadow)
```